### PR TITLE
Larger minesweeper?

### DIFF
--- a/Minesweeper.js
+++ b/Minesweeper.js
@@ -6,12 +6,10 @@ class Minesweeper {
         this.y = y;
         this.w = w;
         this.h = h;
-		this.subsize = 2;
-		if (this.w + this.h == 5) this.subsize = 3;
-		if (this.w + this.h == 6) this.subsize = 4;
+        this.subsize = 2;
+        if (this.w + this.h == 5) this.subsize = 3;
+        if (this.w + this.h == 6) this.subsize = 4;
         this.size = w * h;
-		console.log(this.size);
-		console.log(this.subsize);
 
         this.grid;
         this.visibility = [...Array(this.size * this.subsize)].map(e => Array(this.size * this.subsize));
@@ -27,7 +25,6 @@ class Minesweeper {
             for (let j = 0; j < this.size; j++) {
 
                 let mines = this.createMines(sudoku[i][j]);
-				console.log(mines);
                 grid = this.placeMines(grid, mines, i, j);
             }
         }
@@ -119,7 +116,7 @@ class Minesweeper {
 
                 const x = i * cellSize;
                 const y = j * 60 / this.subsize;
-				const number = this.grid[i][j];
+                const number = this.grid[i][j];
 
                 if (this.visibility[i][j] && !(this.flagged[i][j] && number == '⁕')) {
                     fill("#DBEBE9");
@@ -144,16 +141,16 @@ class Minesweeper {
                     fill(dark);
                     textSize(cellSize * .75);
                 }
-				if (this.flagged[i][j] && !(this.visibility[i][j] && number != '⁕')) {
-					fill(mid);
+                if (this.flagged[i][j] && !(this.visibility[i][j] && number != '⁕')) {
+                    fill(mid);
                     textSize(cellSize * .75);
                     text("?", x + cellSize / 2, y + 60 / this.subsize / 2 + 2);
                 } else if (this.visibility[i][j]) {
-					if (number == '⁕') {
-						text('*', x + cellSize / 2, y + 60 / this.subsize / 2 + 2);
-					} else {
-						text(number, x + cellSize / 2, y + 60 / this.subsize / 2 + 2);
-					}
+                    if (number == '⁕') {
+                        text('*', x + cellSize / 2, y + 60 / this.subsize / 2 + 2);
+                    } else {
+                        text(number, x + cellSize / 2, y + 60 / this.subsize / 2 + 2);
+                    }
                 }
             }
         }

--- a/Minesweeper.js
+++ b/Minesweeper.js
@@ -6,22 +6,28 @@ class Minesweeper {
         this.y = y;
         this.w = w;
         this.h = h;
+		this.subsize = 2;
+		if (this.w + this.h == 5) this.subsize = 3;
+		if (this.w + this.h == 6) this.subsize = 4;
         this.size = w * h;
+		console.log(this.size);
+		console.log(this.subsize);
 
         this.grid;
-        this.visibility = [...Array(this.size * this.w)].map(e => Array(this.size * this.w));
-        this.flagged = [...Array(this.size * this.w)].map(e => Array(this.size * this.w));
+        this.visibility = [...Array(this.size * this.subsize)].map(e => Array(this.size * this.subsize));
+        this.flagged = [...Array(this.size * this.subsize)].map(e => Array(this.size * this.subsize));
         this.exploded = false;
     }
 
     setMines(sudoku) {
 
-        let grid = [...Array(this.size * this.w)].map(e => Array(8));
+        let grid = [...Array(this.size * this.subsize)].map(e => Array(8));
 
         for (let i = 0; i < this.size; i++) {
             for (let j = 0; j < this.size; j++) {
 
                 let mines = this.createMines(sudoku[i][j]);
+				console.log(mines);
                 grid = this.placeMines(grid, mines, i, j);
             }
         }
@@ -36,7 +42,7 @@ class Minesweeper {
 
         let places = [];
 
-        for (let i = 0; i < this.size; i++) {
+        for (let i = 0; i < this.subsize * this.subsize; i++) {
 
             if (i < n) {
                 places.push('⁕');
@@ -50,13 +56,13 @@ class Minesweeper {
 
     placeMines(grid, mines, x, y) {
 
-        for (let i = 0; i < this.w; i++) {
-            for (let j = 0; j < this.h; j++) {
+        for (let i = 0; i < this.subsize; i++) {
+            for (let j = 0; j < this.subsize; j++) {
 
-                const x2 = x * this.w + i;
-                const y2 = y * this.h + j;
+                const x2 = x * this.subsize + i;
+                const y2 = y * this.subsize + j;
 
-                grid[x2][y2] = mines[j * this.w + i];
+                grid[x2][y2] = mines[j * this.subsize + i];
             }
         }
         return grid;
@@ -64,8 +70,8 @@ class Minesweeper {
 
     getClues(grid) {
 
-        for (let i = 0; i < this.size * this.w; i++) {
-            for (let j = 0; j < this.size * this.h; j++) {
+        for (let i = 0; i < this.size * this.subsize; i++) {
+            for (let j = 0; j < this.size * this.subsize; j++) {
 
                 if (grid[i][j] == '⁕') {
                     continue;
@@ -90,7 +96,7 @@ class Minesweeper {
                 if (i == x && j == y) {
                     continue;
                 }
-                if (i < 0 || i >= this.size * this.w || j < 0 || j >= this.size * this.h) {
+                if (i < 0 || i >= this.size * this.subsize || j < 0 || j >= this.size * this.subsize) {
                     continue;
                 }
                 if (grid[i][j] == '⁕') {
@@ -106,28 +112,27 @@ class Minesweeper {
         push();
         translate(this.x, this.y);
 
-        const cellSize = 60 / this.w;
+        const cellSize = 60 / this.subsize;
 
-        for (let i = 0; i < this.size * this.w; i++) {
-            for (let j = 0; j < this.size * this.h; j++) {
+        for (let i = 0; i < this.size * this.subsize; i++) {
+            for (let j = 0; j < this.size * this.subsize; j++) {
 
                 const x = i * cellSize;
-                const y = j * 60 / this.h;
+                const y = j * 60 / this.subsize;
+				const number = this.grid[i][j];
 
-                if (this.visibility[i][j]) {
+                if (this.visibility[i][j] && !(this.flagged[i][j] && number == '⁕')) {
                     fill("#DBEBE9");
                 } else {
                     fill(white);
                 }
                 stroke(dark);
                 strokeWeight(1);
-                rect(x, y, cellSize, 60 / this.h);
+                rect(x, y, cellSize, 60 / this.subsize);
 
                 noStroke();
                 textAlign(CENTER, CENTER);
                 textFont('Fira Code');
-
-                const number = this.grid[i][j];
 
                 if (number == '⁕') {
 
@@ -139,13 +144,16 @@ class Minesweeper {
                     fill(dark);
                     textSize(cellSize * .75);
                 }
-                if (this.visibility[i][j]) {
-                    text(number, x + cellSize / 2, y + 60 / this.h / 2 + 2);
-                } else if (this.flagged[i][j]) {
-
-                    fill(mid);
+				if (this.flagged[i][j] && !(this.visibility[i][j] && number != '⁕')) {
+					fill(mid);
                     textSize(cellSize * .75);
-                    text("?", x + cellSize / 2, y + 60 / this.h / 2 + 2);
+                    text("?", x + cellSize / 2, y + 60 / this.subsize / 2 + 2);
+                } else if (this.visibility[i][j]) {
+					if (number == '⁕') {
+						text('*', x + cellSize / 2, y + 60 / this.subsize / 2 + 2);
+					} else {
+						text(number, x + cellSize / 2, y + 60 / this.subsize / 2 + 2);
+					}
                 }
             }
         }
@@ -155,7 +163,7 @@ class Minesweeper {
 
     drawGuidelines(cellSize) {
 
-        cellSize *= this.w;
+        cellSize *= this.subsize;
 
         for (let i = 0; i < this.size; i++) {
             for (let j = 0; j < this.size; j++) {
@@ -183,13 +191,13 @@ class Minesweeper {
         x -= this.x;
         y -= this.y;
 
-        let cellSize = 60/this.w;
+        let cellSize = 60/this.subsize;
 
-        for (let i = 0; i < this.size * this.w; i++) {
-            for (let j = 0; j < this.size * this.h; j++) {
+        for (let i = 0; i < this.size * this.subsize; i++) {
+            for (let j = 0; j < this.size * this.subsize; j++) {
 
                 if (x > i * cellSize && x < i * cellSize + cellSize) {
-                    if (y > j * 60 / this.h && y < j * 60 / this.h + 60 / this.h) {
+                    if (y > j * 60 / this.subsize && y < j * 60 / this.subsize + 60 / this.subsize) {
 
                         if (startTime == "") {
                             startTime = new Date();
@@ -219,8 +227,8 @@ class Minesweeper {
 
     explode() {
 
-        for (let i = 0; i < this.size * this.w; i++) {
-            for (let j = 0; j < this.size * this.h; j++) {
+        for (let i = 0; i < this.size * this.subsize; i++) {
+            for (let j = 0; j < this.size * this.subsize; j++) {
 
                 this.visibility[i][j] = true;
                 this.exploded = true;
@@ -235,7 +243,7 @@ class Minesweeper {
 
                 if (i == x && j == y) {
                     continue;
-                } else if (i < 0 || j < 0 || i >= this.size * this.w || j >= this.size * this.h) {
+                } else if (i < 0 || j < 0 || i >= this.size * this.subsize || j >= this.size * this.subsize) {
                     continue;
                 }
                 if (!this.visibility[i][j]) {
@@ -266,7 +274,7 @@ class Minesweeper {
                 if (i == x && j == y) {
                     continue;
                 }
-                if (i < 0 || i >= this.size * this.w || j < 0 || j >= this.size * this.h) {
+                if (i < 0 || i >= this.size * this.subsize || j < 0 || j >= this.size * this.subsize) {
                     continue;
                 }
                 if (this.flagged[i][j] && !this.visibility[i][j]) {
@@ -282,7 +290,7 @@ class Minesweeper {
         for (let i = x-1; i <= x+1; i++) {
             for (let j = y-1; j <= y+1; j++) {
 
-                if (i >= 0 && j >= 0 && i < this.size * this.w && j < this.size * this.h) {
+                if (i >= 0 && j >= 0 && i < this.size * this.subsize && j < this.size * this.subsize) {
 
                     if (this.flagged[i][j]) {
                         // continue;
@@ -304,8 +312,8 @@ class Minesweeper {
         if (this.exploded) {
             return false;
         }
-        for (let i = 0; i < this.size * this.w; i++) {
-            for (let j = 0; j < this.size * this.h; j++) {
+        for (let i = 0; i < this.size * this.subsize; i++) {
+            for (let j = 0; j < this.size * this.subsize; j++) {
 
                 if (!this.visibility[i][j] && this.grid[i][j] != "⁕") {
                     return false;


### PR DESCRIPTION
Increase the minesweeper size from 2x2/2x3/3x3 to 2x2/3x3/4x4. Makes the larger sizes more doable. May have bugs.

Also makes the flags visible after you lose a game. Also I replaced the ⁕ symbol with a * for displaying mines, because it wasn't showing up for me, feel free to reverse that.